### PR TITLE
added ability to associate an interface with a request or alias

### DIFF
--- a/cmd/wol/alias.go
+++ b/cmd/wol/alias.go
@@ -6,11 +6,16 @@ import (
 	"os/user"
 )
 
+type MacIface struct {
+	Mac   string
+	Iface string
+}
+
 // Loads the user aliases from the aliases gob stored in
 // ~/.config/go-wol/aliases
-func loadUserAliases() (map[string]string, error) {
+func loadUserAliases() (map[string]MacIface, error) {
 	var file *os.File
-	ret := make(map[string]string)
+	ret := make(map[string]MacIface)
 
 	usr, err := user.Current()
 	if err != nil {
@@ -36,7 +41,7 @@ func loadUserAliases() (map[string]string, error) {
 
 // Flushes the user aliases to the aliases gob stored in
 // ~/.config/go-wol/aliases
-func flushUserAliases(m map[string]string) error {
+func flushUserAliases(m map[string]MacIface) error {
 	var file *os.File
 
 	usr, err := user.Current()

--- a/cmd/wol/usage.go
+++ b/cmd/wol/usage.go
@@ -31,10 +31,10 @@ var ValidOptions = []struct {
 var UsageString = `Usage:
 
     To wake up a machine:
-        <cyan>wol</cyan> [<options>] <yellow>wake</yellow> <mac address | alias>
+        <cyan>wol</cyan> [<options>] <yellow>wake</yellow> <mac address | alias> <optional interface>
 
     To store an alias:
-        <cyan>wol</cyan> [<options>] <yellow>alias</yellow> <alias> <mac address>
+        <cyan>wol</cyan> [<options>] <yellow>alias</yellow> <alias> <mac address> <optional interface>
 
     To view aliases:
         <cyan>wol</cyan> [<options>] <yellow>list</yellow>

--- a/cmd/wol/version.go
+++ b/cmd/wol/version.go
@@ -28,4 +28,4 @@ Specify the Broadcast Port and IP
 package main
 
 // Version represents the current Semantic Version of this application
-const Version = "1.0.0"
+const Version = "1.0.1"

--- a/cmd/wol/wol.go
+++ b/cmd/wol/wol.go
@@ -7,8 +7,7 @@ import (
 	"errors"
 
 	"github.com/sabhiram/go-colorize"
-	//wol "github.com/sabhiram/go-wol"
-	wol "github.com/traetox/go-wol"
+	wol "github.com/sabhiram/go-wol"
 
 	"github.com/jessevdk/go-flags"
 )

--- a/cmd/wol/wol.go
+++ b/cmd/wol/wol.go
@@ -7,7 +7,8 @@ import (
 	"errors"
 
 	"github.com/sabhiram/go-colorize"
-	wol "github.com/sabhiram/go-wol"
+	//wol "github.com/sabhiram/go-wol"
+	wol "github.com/traetox/go-wol"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -23,30 +24,38 @@ var (
 )
 
 // Run the alias command
-func runAliasCommand(args []string, aliases map[string]string) error {
+func runAliasCommand(args []string, aliases map[string]MacIface) error {
 	if len(args) >= 2 {
+		var eth string
+		if len(args) > 2 {
+			eth = args[2]
+		}
 		// TODO: Validate mac address
 		alias, mac := args[0], args[1]
-		aliases[alias] = mac
+		aliases[alias] = MacIface{Mac: mac, Iface: eth}
 		return flushUserAliases(aliases)
 	}
 	return errors.New("alias command requires a <name> and a <mac>")
 }
 
 // Run the list command
-func runListCommand(args []string, aliases map[string]string) error {
+func runListCommand(args []string, aliases map[string]MacIface) error {
 	if len(aliases) == 0 {
 		fmt.Printf("No aliases found! Add one with \"wol alias <name> <mac>\"\n")
 	} else {
-		for alias, mac := range aliases {
-			fmt.Printf("    %s - %s\n", alias, mac)
+		for alias, mi := range aliases {
+			if mi.Iface == "" {
+				fmt.Printf("    %s - %s\n", alias, mi.Mac)
+			} else {
+				fmt.Printf("    %s - %s %s\n", alias, mi.Mac, mi.Iface)
+			}
 		}
 	}
 	return nil
 }
 
 // Run the remove command
-func runRemoveCommand(args []string, aliases map[string]string) error {
+func runRemoveCommand(args []string, aliases map[string]MacIface) error {
 	if len(args) > 0 {
 		alias := args[0]
 		delete(aliases, alias)
@@ -56,16 +65,21 @@ func runRemoveCommand(args []string, aliases map[string]string) error {
 }
 
 // Run the wake command
-func runWakeCommand(args []string, aliases map[string]string) error {
+func runWakeCommand(args []string, aliases map[string]MacIface) error {
 	if len(args) > 0 {
+		var eth string
 		macAddr := args[0]
+		if len(args) > 1 {
+			eth = args[1]
+		}
 
 		// If we got an alias - use that as the mac addr
 		if val, ok := aliases[macAddr]; ok {
-			macAddr = val
+			macAddr = val.Mac
+			eth = val.Iface
 		}
 
-		err := wol.SendMagicPacket(macAddr, Options.BroadcastIP + ":" + Options.UDPPort)
+		err := wol.SendMagicPacket(macAddr, Options.BroadcastIP+":"+Options.UDPPort, eth)
 		if err != nil {
 			return errors.New("Unable to send magic packet")
 		}
@@ -77,7 +91,7 @@ func runWakeCommand(args []string, aliases map[string]string) error {
 }
 
 // Run one of the supported commands
-func runCommand(cmd string, args []string, aliases map[string]string) error {
+func runCommand(cmd string, args []string, aliases map[string]MacIface) error {
 	switch cmd {
 
 	case "alias":


### PR DESCRIPTION
The updated functionality allows for associating an interface with an alias and a wake.  Alot of my machines have multiple interfaces this ensures that the WOL packets go out over the correct interface.  Specifying an interface is optional and the behavior is identical if no interface is supplied.

Unfortunately the alias gob file from before won't be compatible with the updated alias structure.