### PR TITLE
Updated type that returned the wrong error

### DIFF
--- a/cmd/wol/alias.go
+++ b/cmd/wol/alias.go
@@ -53,7 +53,7 @@ func LoadAliases(dbpath string) (*Aliases, error) {
 	}
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, lerr := tx.CreateBucketIfNotExists([]byte(MainBucketName)); err != nil {
+		if _, lerr := tx.CreateBucketIfNotExists([]byte(MainBucketName)); lerr != nil {
 			return lerr
 		}
 		return nil


### PR DESCRIPTION
I was referencing the code and found a typo on returning an hour.