### PR TITLE
chore(imports): switch to coreos boltDB fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.3
+  - "1.10"
   - tip
 
 env:

--- a/cmd/wol/alias.go
+++ b/cmd/wol/alias.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"sync"
 
-	"github.com/boltdb/bolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 const (

--- a/cmd/wol/alias_test.go
+++ b/cmd/wol/alias_test.go
@@ -60,13 +60,6 @@ func TestEncodeFromMacIface(test *testing.T) {
 	}
 }
 
-// Validate that an invalid db path errors out
-func TestInvalidDbPath(test *testing.T) {
-	aliases, err := LoadAliases("./dir/no/existy/_test_TestInvalidDbPath")
-	assert.NotNil(test, err)
-	assert.Nil(test, aliases)
-}
-
 //////////////////////////////////////////////////////////////////////////////
 // Test suite: AliasDBTests
 //      Validate various parts of the DB functionality which needs


### PR DESCRIPTION
Update BoltDB import to maintained fork and remove redundant test (LoadAliases created dbpath).

https://github.com/sabhiram/go-wol/issues/10